### PR TITLE
Add fallback if "blacklisted" missing in response

### DIFF
--- a/mullvad_python/api.py
+++ b/mullvad_python/api.py
@@ -29,7 +29,9 @@ class Mullpy():
             self.exit_hostname = self.api_data['mullvad_exit_ip_hostname']
             self.organization = self.api_data['organization']
             self.server_type = self.api_data['mullvad_server_type']
-        self.blacklisted = self.api_data['blacklisted']
+        self.blacklisted = self.api_data.get(
+            'blacklisted', {'blacklisted': False, 'results': []}
+        )
 
     def is_blacklisted(self):
         """Return True or False if user is blacklisted."""


### PR DESCRIPTION
In my case the "Am I Mullvad" API was missing the `"blacklisted"` information entirely. This patch will fix mullpy to take that into account.

```
$ curl https://am.i.mullvad.net/json
{"ip":"2a03:1b20:........","country":"United Kingdom","city":"London","longitude":-0.0638,"latitude":51.5128,"mullvad_exit_ip":true,"mullvad_exit_ip_hostname":"gbXX-wireguard","mullvad_server_type":"WireGuard","organization":"31173 Services United Kingdom"}
```

```
$ mullpy                   
Traceback (most recent call last):
  File "/home/linus/.local/bin/mullpy", line 8, in <module>
    sys.exit(main())
  File "/home/linus/.local/lib/python3.8/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/linus/.local/lib/python3.8/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/linus/.local/lib/python3.8/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/linus/.local/lib/python3.8/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/linus/.local/lib/python3.8/site-packages/mullvad_python/cli.py", line 12, in main
    mullpy = Mullpy()
  File "/home/linus/.local/lib/python3.8/site-packages/mullvad_python/api.py", line 32, in __init__
    self.blacklisted = self.api_data['blacklisted']
KeyError: 'blacklisted'
```
